### PR TITLE
Fix local_rst signal not connecting

### DIFF
--- a/pygears/hdl/sv/svmod.py
+++ b/pygears/hdl/sv/svmod.py
@@ -125,6 +125,8 @@ class SVModuleGen(HDLModuleInst):
         except:
             pass
 
+        self.node.params['sigmap']['rst'] = rst_name
+
         context = {
             'rst_name': rst_name,
             'module_name': self.module_name,


### PR DESCRIPTION
snippet.j2 is now looking for sigmap names which is set as {'clk': 'clk', 'rst': 'rst"} by default.
When local_rst is present in module, 'rst' should be 'rst_local'.

Maybe "self.node.params['sigmap']['rst'] = rst_name" is not safe.
Should safe_bind() be used instead?
